### PR TITLE
feat: make KG title configurable

### DIFF
--- a/finops-kg/web/server.mjs
+++ b/finops-kg/web/server.mjs
@@ -16,6 +16,7 @@ app.use(cors());
 const PORT = process.env.PORT || 3000;
 const OLLAMA_BASE_URL =
   process.env.OLLAMA_BASE_URL || "http://host.docker.internal:11434";
+const KG_NAME = process.env.KG_NAME || "FinOps KG";
 
 // --- Graph storage ---
 const graphsDir = path.join(__dirname, "graphs");
@@ -97,6 +98,6 @@ app.use(express.static(pub));
 app.get("*", (_, res) => res.sendFile(path.join(pub, "index.html")));
 
 app.listen(PORT, () => {
-  console.log(`Graph Theory KG on http://localhost:${PORT}`);
+  console.log(`${KG_NAME} on http://localhost:${PORT}`);
   console.log(`Proxy -> ${OLLAMA_BASE_URL}/api/generate`);
 });

--- a/graph-theory-kg/web/server.mjs
+++ b/graph-theory-kg/web/server.mjs
@@ -16,6 +16,7 @@ app.use(cors());
 const PORT = process.env.PORT || 3000;
 const OLLAMA_BASE_URL =
   process.env.OLLAMA_BASE_URL || "http://host.docker.internal:11434";
+const KG_NAME = process.env.KG_NAME || "Graph Theory KG";
 
 // --- Graph storage ---
 const graphsDir = path.join(__dirname, "graphs");
@@ -97,6 +98,6 @@ app.use(express.static(pub));
 app.get("*", (_, res) => res.sendFile(path.join(pub, "index.html")));
 
 app.listen(PORT, () => {
-  console.log(`Graph Theory KG on http://localhost:${PORT}`);
+  console.log(`${KG_NAME} on http://localhost:${PORT}`);
   console.log(`Proxy -> ${OLLAMA_BASE_URL}/api/generate`);
 });


### PR DESCRIPTION
## Summary
- read `KG_NAME` environment variable in each web server with a sensible default
- log the correct FinOps and Graph Theory KG titles on startup

## Testing
- `npm test` (finops-kg/web) *(fails: Missing script "test")*
- `npm test` (graph-theory-kg/web) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0867f93ac8325a58e4e69d89c0c63