### PR TITLE
Persist graph uploads via volume

### DIFF
--- a/finops-kg/docker-compose.yml
+++ b/finops-kg/docker-compose.yml
@@ -10,4 +10,6 @@ services:
     extra_hosts:
       # Ensures the container can reach your host on Linux too
       - "host.docker.internal:host-gateway"
+    volumes:
+      - ./web/graphs:/app/graphs
     restart: unless-stopped

--- a/graph-theory-kg/docker-compose.yml
+++ b/graph-theory-kg/docker-compose.yml
@@ -10,4 +10,6 @@ services:
     extra_hosts:
       # Ensures the container can reach your host on Linux too
       - "host.docker.internal:host-gateway"
+    volumes:
+      - ./web/graphs:/app/graphs
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Mount `./web/graphs` into `/app/graphs` for finops and graph-theory KGs to persist uploaded graphs.

## Testing
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0867e454c8325b9dbef7941f3facb