### PR TITLE
Handle failed graph uploads

### DIFF
--- a/graph-theory-kg/web/public/main.js
+++ b/graph-theory-kg/web/public/main.js
@@ -13,7 +13,8 @@
     const files = Array.from(e.target.files || []);
     const graphs = await Promise.all(files.map(async f => ({ name:f.name, data: JSON.parse(await f.text()) })));
     if (graphs.length) {
-      await fetch("/graphs", { method:"POST", headers:{"Content-Type":"application/json"}, body:JSON.stringify({ graphs }) });
+      const resp = await fetch("/graphs", { method:"POST", headers:{"Content-Type":"application/json"}, body:JSON.stringify({ graphs }) });
+      if (!resp.ok) { flash("Upload failed"); return; }
       location.search = `?graph=${graphs[0].name}`;
     }
   });


### PR DESCRIPTION
## Summary
- Capture fetch response when uploading graphs
- Display a flash message if the upload fails instead of redirecting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0867cb014832587db810e4e51d8b3