### PR TITLE
Include graphs directory in Docker images

### DIFF
--- a/finops-kg/web/Dockerfile
+++ b/finops-kg/web/Dockerfile
@@ -6,6 +6,7 @@ RUN npm i --omit=dev
 
 COPY server.mjs ./server.mjs
 COPY public ./public
+COPY graphs ./graphs
 
 ENV PORT=3000
 EXPOSE 3000

--- a/graph-theory-kg/web/Dockerfile
+++ b/graph-theory-kg/web/Dockerfile
@@ -6,6 +6,7 @@ RUN npm i --omit=dev
 
 COPY server.mjs ./server.mjs
 COPY public ./public
+COPY graphs ./graphs
 
 ENV PORT=3000
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Bundle graphs JSON data in Docker images for graph-theory and FinOps KGs

## Testing
- `npm test` (fails: Missing script: "test")
- `docker build -t graph-theory-kg-web .` (fails: command not found: docker)
- `apt-get update` (fails: repository not signed / 403)


------
https://chatgpt.com/codex/tasks/task_e_68a08674373c83259afcfb8f90db5ac9